### PR TITLE
Fix 'droid_backends' Compilation and Path Issues in Configs

### DIFF
--- a/configs/Replica/office0.yaml
+++ b/configs/Replica/office0.yaml
@@ -16,6 +16,6 @@ inherit_from: configs/Replica/replica.yaml
 scene: office0
 
 meshing:
-  gt_mesh_path: /cluster/project/cvl/esandstroem/src/glorie-slam/cull_replica_mesh/office0.ply
+  gt_mesh_path: cull_replica_mesh/office0.ply
 data:
   input_folder: office0

--- a/configs/Replica/office1.yaml
+++ b/configs/Replica/office1.yaml
@@ -20,6 +20,6 @@ tracking:
     keyframe_thresh: 4.00
 
 meshing:
-  gt_mesh_path: /cluster/project/cvl/esandstroem/src/glorie-slam/cull_replica_mesh/office1.ply
+  gt_mesh_path: cull_replica_mesh/office1.ply
 data:
   input_folder: office1

--- a/configs/Replica/office2.yaml
+++ b/configs/Replica/office2.yaml
@@ -16,6 +16,6 @@ inherit_from: configs/Replica/replica.yaml
 scene: office2
 
 meshing:
-  gt_mesh_path: /cluster/project/cvl/esandstroem/src/glorie-slam/cull_replica_mesh/office2.ply
+  gt_mesh_path: cull_replica_mesh/office2.ply
 data:
   input_folder: office2

--- a/configs/Replica/office3.yaml
+++ b/configs/Replica/office3.yaml
@@ -16,6 +16,6 @@ inherit_from: configs/Replica/replica.yaml
 scene: office3
 
 meshing:
-  gt_mesh_path: /cluster/project/cvl/esandstroem/src/glorie-slam/cull_replica_mesh/office3.ply
+  gt_mesh_path: cull_replica_mesh/office3.ply
 data:
   input_folder: office3

--- a/configs/Replica/office4.yaml
+++ b/configs/Replica/office4.yaml
@@ -20,6 +20,6 @@ tracking:
     keyframe_thresh: 2.75 
 
 meshing:
-  gt_mesh_path: /cluster/project/cvl/esandstroem/src/glorie-slam/cull_replica_mesh/office4.ply
+  gt_mesh_path: cull_replica_mesh/office4.ply
 data:
   input_folder: office4

--- a/configs/Replica/replica.yaml
+++ b/configs/Replica/replica.yaml
@@ -54,4 +54,5 @@ cam:
   W_out: 640
 
 data:
+  dataset_root: datasets/Replica
   output: /cluster/work/cvl/esandstroem/src/splat-slam/output/Replica

--- a/configs/Replica/replica.yaml
+++ b/configs/Replica/replica.yaml
@@ -55,4 +55,4 @@ cam:
 
 data:
   dataset_root: datasets/Replica
-  output: /cluster/work/cvl/esandstroem/src/splat-slam/output/Replica
+  output: output/Replica

--- a/configs/Replica/room0.yaml
+++ b/configs/Replica/room0.yaml
@@ -16,6 +16,6 @@ inherit_from: configs/Replica/replica.yaml
 scene: room0
 
 meshing:
-  gt_mesh_path: /cluster/project/cvl/esandstroem/src/glorie-slam/cull_replica_mesh/room0.ply
+  gt_mesh_path: cull_replica_mesh/room0.ply
 data:
   input_folder: room0

--- a/configs/Replica/room1.yaml
+++ b/configs/Replica/room1.yaml
@@ -21,6 +21,6 @@ tracking:
     keyframe_thresh: 2.75  
 
 meshing:
-  gt_mesh_path: /cluster/project/cvl/esandstroem/src/glorie-slam/cull_replica_mesh/room1.ply
+  gt_mesh_path: cull_replica_mesh/room1.ply
 data:
   input_folder: room1

--- a/configs/Replica/room2.yaml
+++ b/configs/Replica/room2.yaml
@@ -16,6 +16,6 @@ inherit_from: configs/Replica/replica.yaml
 scene: room2
 
 meshing:
-  gt_mesh_path: /cluster/project/cvl/esandstroem/src/glorie-slam/cull_replica_mesh/room2.ply
+  gt_mesh_path: cull_replica_mesh/room2.ply
 data:
   input_folder: room2

--- a/configs/Scannet/scannet.yaml
+++ b/configs/Scannet/scannet.yaml
@@ -50,5 +50,5 @@ cam:
 
 data:
   dataset_root: datasets/Scannet
-  output: /cluster/work/cvl/esandstroem/src/mono_point_slam/output/Scannet
+  output: output/Scannet
 

--- a/configs/Scannet/scannet.yaml
+++ b/configs/Scannet/scannet.yaml
@@ -49,5 +49,6 @@ cam:
   W_out: 320
 
 data:
+  dataset_root: datasets/Scannet
   output: /cluster/work/cvl/esandstroem/src/mono_point_slam/output/Scannet
 

--- a/configs/TUM_RGBD/tum.yaml
+++ b/configs/TUM_RGBD/tum.yaml
@@ -42,4 +42,4 @@ cam:  #NOTE: intrinsic is different per scene in TUM
 
 data:
   dataset_root: datasets/TUM_RGBD
-  output: /cluster/work/cvl/esandstroem/src/splat-slam/output/TUM_RGBD
+  output: output/TUM_RGBD

--- a/configs/TUM_RGBD/tum.yaml
+++ b/configs/TUM_RGBD/tum.yaml
@@ -41,4 +41,5 @@ cam:  #NOTE: intrinsic is different per scene in TUM
   W_out: 512
 
 data:
+  dataset_root: datasets/TUM_RGBD
   output: /cluster/work/cvl/esandstroem/src/splat-slam/output/TUM_RGBD

--- a/configs/splat_slam.yaml
+++ b/configs/splat_slam.yaml
@@ -86,7 +86,7 @@ mapping:
     compute_cov3D_python: False
 
 tracking:
-  pretrained: /cluster/project/cvl/esandstroem/src/glorie-slam/pretrained/droid.pth
+  pretrained: pretrained/droid.pth
   buffer: 512     # maximum number of keyframes that can be stored
   beta: 0.75      # beta * Distance(R|t) + (1-beta) * Distance(I|t), refer to droid_kernels.cu:frame_distance_kernel
   warmup: 8       # use the first X keyframes for bootstrapping the tracker
@@ -135,5 +135,5 @@ meshing:
 
 mono_prior:
   depth: omnidata      # mono depth model, only omnidata supported for now
-  depth_pretrained: /cluster/project/cvl/esandstroem/src/glorie-slam/pretrained/omnidata_dpt_depth_v2.ckpt
+  depth_pretrained: pretrained/omnidata_dpt_depth_v2.ckpt
   predict_online: True # whether to predict the mono depth prior online, if False, need to pre-run mono prior first and store the mono depth map.

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@ setup(
     name='droid_backends',
     ext_modules=[
         CUDAExtension('droid_backends',
-            include_dirs=[osp.join(ROOT, 'thirdparty/eigen')],
+            include_dirs=[osp.join(ROOT, 'thirdparty/lietorch/eigen')],
             sources=[
-                'src/lib/droid.cpp',
-                'src/lib/droid_kernels.cu',
-                'src/lib/correlation_kernels.cu',
-                'src/lib/altcorr_kernel.cu',
+                'thirdparty/glorie_slam/lib/droid.cpp',
+                'thirdparty/glorie_slam/lib/droid_kernels.cu',
+                'thirdparty/glorie_slam/lib/correlation_kernels.cu',
+                'thirdparty/glorie_slam/lib/altcorr_kernel.cu',
             ],
             extra_compile_args={
                 'cxx': ['-O3'],

--- a/src/mapper.py
+++ b/src/mapper.py
@@ -357,7 +357,7 @@ class Mapper(object):
 
         # online plotting
         if self.online_plotting:
-            from gaussian_splatting.utils.image_utils import psnr
+            from thirdparty.gaussian_splatting.utils.image_utils import psnr
             from src.utils.eval_utils import plot_rgbd_silhouette
             import cv2
             import numpy as np
@@ -569,7 +569,7 @@ class Mapper(object):
 
         # online plotting
         if self.online_plotting:
-            from gaussian_splatting.utils.image_utils import psnr
+            from thirdparty.gaussian_splatting.utils.image_utils import psnr
             from src.utils.eval_utils import plot_rgbd_silhouette
             import cv2
             import numpy as np

--- a/src/utils/datasets.py
+++ b/src/utils/datasets.py
@@ -110,8 +110,7 @@ class BaseDataset(Dataset):
             cfg['cam']['distortion']) if 'distortion' in cfg['cam'] else None
 
         # retrieve input folder as temporary folder
-        tmpdir = os.environ.get('TMPDIR')
-        self.input_folder = tmpdir + '/' + cfg['data']['input_folder']
+        self.input_folder = os.path.join(cfg['data']['dataset_root'], cfg['data']['input_folder'])
         
 
     def __len__(self):

--- a/thirdparty/gaussian_splatting/gaussian_renderer/__init__.py
+++ b/thirdparty/gaussian_splatting/gaussian_renderer/__init__.py
@@ -17,8 +17,8 @@ from diff_gaussian_rasterization import (
     GaussianRasterizer,
 )
 
-from gaussian_splatting.scene.gaussian_model import GaussianModel
-from gaussian_splatting.utils.sh_utils import eval_sh
+from thirdparty.gaussian_splatting.scene.gaussian_model import GaussianModel
+from thirdparty.gaussian_splatting.utils.sh_utils import eval_sh
 
 
 def render(

--- a/thirdparty/gaussian_splatting/scene/gaussian_model.py
+++ b/thirdparty/gaussian_splatting/scene/gaussian_model.py
@@ -18,7 +18,7 @@ from plyfile import PlyData, PlyElement
 from simple_knn._C import distCUDA2
 from torch import nn
 
-from gaussian_splatting.utils.general_utils import (
+from thirdparty.gaussian_splatting.utils.general_utils import (
     build_rotation,
     build_scaling_rotation,
     get_expon_lr_func,
@@ -26,9 +26,9 @@ from gaussian_splatting.utils.general_utils import (
     inverse_sigmoid,
     strip_symmetric,
 )
-from gaussian_splatting.utils.graphics_utils import BasicPointCloud, getWorld2View2
-from gaussian_splatting.utils.sh_utils import RGB2SH
-from gaussian_splatting.utils.system_utils import mkdir_p
+from thirdparty.gaussian_splatting.utils.graphics_utils import BasicPointCloud, getWorld2View2
+from thirdparty.gaussian_splatting.utils.sh_utils import RGB2SH
+from thirdparty.gaussian_splatting.utils.system_utils import mkdir_p
 
 
 class GaussianModel:


### PR DESCRIPTION
- Fixed compilation errors in `droid_backends` by updating include paths and sources.
- Corrected import paths in the `gaussian_splatting` package to resolve runtime import errors.
- Updated file paths in configuration files for `dataset_root` and `output` directories.