### PR TITLE
Add Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,41 @@
+FROM pytorch/pytorch:2.0.1-cuda11.7-cudnn8-devel
+
+ENV DEBIAN_FRONTEND=noninteractive \
+    PATH="/opt/miniforge3/bin:$PATH" \
+    TORCH_CUDA_ARCH_LIST="8.0+PTX"
+
+RUN apt update && \
+    apt install -y --no-install-recommends tzdata git unzip wget libglib2.0-0 libgl1-mesa-glx && \
+    wget -O Miniforge3.sh https://github.com/conda-forge/miniforge/releases/latest/download/Miniforge3-Linux-x86_64.sh && \
+    bash Miniforge3.sh -b -p /opt/miniforge3 && \
+    rm Miniforge3.sh && \
+    apt clean && rm -rf /var/lib/apt/lists/*
+    
+
+WORKDIR /workspace
+RUN git clone https://github.com/google-research/Splat-SLAM.git --recursive
+
+WORKDIR /workspace/Splat-SLAM
+RUN conda create -n splat-slam python=3.10 && \
+    conda clean -a -y
+
+SHELL ["conda", "run", "-n", "splat-slam", "/bin/bash", "-c"]
+
+RUN pip install --no-cache-dir torch torchvision torchaudio --index-url https://download.pytorch.org/whl/cu118 && \
+    sed -i 's/p_view\.z <= 0\.2f/p_view\.z <= 0\.001f/' /workspace/Splat-SLAM/thirdparty/diff-gaussian-rasterization-w-pose/cuda_rasterizer/auxiliary.h && \
+    pip install --no-cache-dir -e thirdparty/lietorch/ \
+                                   thirdparty/diff-gaussian-rasterization-w-pose/ \
+                                   thirdparty/simple-knn/ \
+                                   thirdparty/evaluate_3d_reconstruction_lib/ && \
+    pip install --no-cache-dir -e . && \
+    pip install --no-cache-dir -r requirements.txt && \
+    pip install --no-cache-dir pytorch-lightning==1.9 --no-deps && \
+    pip install --no-cache-dir gdown
+
+RUN conda init bash && \
+    echo "conda activate splat-slam" >> ~/.bashrc
+
+COPY download_pretrained_model.sh /usr/local/bin/download_pretrained_model.sh
+RUN chmod +x /usr/local/bin/download_pretrained_model.sh
+
+CMD ["tail", "-f", "/dev/null"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  splat-slam:
+    container_name: splat-slam
+    build:
+      context: .
+      dockerfile: Dockerfile
+    entrypoint: /usr/local/bin/download_pretrained_model.sh
+    command: tail -f /dev/null
+    tty: true
+    volumes:
+      - ./pretrained_models:/workspace/Splat-SLAM/pretrained
+      - ./data:/workspace/Splat-SLAM/datasets
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              device_ids: ["0"]
+              capabilities: [gpu]

--- a/download_pretrained_model.sh
+++ b/download_pretrained_model.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+source /opt/miniforge3/etc/profile.d/conda.sh
+conda init bash && conda activate splat-slam
+
+MODEL_DIR="/workspace/Splat-SLAM/pretrained"
+MODEL_ZIP="$MODEL_DIR/glorie-pretrained.zip"
+MODEL_PATH="$MODEL_DIR/omnidata_dpt_depth_v2.ckpt"
+
+if [ -f "$MODEL_PATH" ]; then
+    echo "Model already exists. Skipping download."
+else
+    echo "Model not found. Downloading..."
+    gdown https://drive.google.com/uc?id=1oZbVPrubtaIUjRRuT8F-YjjHBW-1spKT -O "$MODEL_ZIP" 
+    unzip "$MODEL_ZIP" -d "$MODEL_DIR"
+    rm "$MODEL_ZIP"
+    rm "$MODEL_DIR/middle_fine.pt"
+    echo "Model downloaded successfully."
+fi
+
+exec "$@"


### PR DESCRIPTION
Created a Dockerfile for this repo. This also automatically downloads the pretrained model to the bind mount `./pretrained_models:/workspace/Splat-SLAM/pretrained`. It creates a conda environment in the container and installs the packages with pip. Downloaded datasets, when following the readme, will be placed in the bind mount `./data:/workspace/Splat-SLAM/datasets`
`TORCH_CUDA_ARCH_LIST` should be set manually for each specific GPU that is going to be used.
